### PR TITLE
Fix cargo install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ build = "./src/build.rs"
 [dependencies]
 chrono = "0.4.13"
 cmd_lib = "0.8.2"
+cmd_lib_core = "0.1.0"
 lazy_static = "1.4.0"
 regex = "1.3.9"
 sysinfo = "0.15.0"


### PR DESCRIPTION
This commit fixes the error that occurred when running `cargo install --path .`