### PR TITLE
Add support for Host for the model

### DIFF
--- a/src/assets/defaults/info.lua
+++ b/src/assets/defaults/info.lua
@@ -39,6 +39,16 @@ if kernel ~= nil then
 		..kernel.version)
 end
 
+if host ~= nil then
+	print(""
+		..bold()
+		..distroColors[2]
+		.."Host"
+		..reset()
+		..": "
+		..host.model)
+end
+
 -- Uptime
 if uptime ~= nil then
 	local output = ""
@@ -66,7 +76,7 @@ if uptime ~= nil then
 		comma()
 		output = output..uptime.seconds.." second"..s(uptime.seconds)
 	end
-	
+
 	print(""
 		..bold()
 		..distroColors[2]

--- a/src/info/host.rs
+++ b/src/info/host.rs
@@ -1,0 +1,43 @@
+use crate::errors;
+use crate::mlua;
+use crate::Inject;
+
+use super::kernel::Kernel;
+use mlua::prelude::*;
+
+use std::fs::read_to_string;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Host {
+    pub model: String,
+}
+
+impl Host {
+    pub fn new(k: &Kernel) -> Option<Self> {
+        match &*k.name {
+            "Linux" => Some(Host {
+                model: read_to_string("/sys/devices/virtual/dmi/id/product_name").unwrap(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl Inject for Host {
+    fn inject(&self, lua: &mut Lua) {
+        let globals = lua.globals();
+        match lua.create_table() {
+            Ok(t) => {
+                match t.set("model", self.model.as_str()) {
+                    Ok(_) => (),
+                    Err(e) => errors::handle(&format!("{}{}", errors::LUA, e)),
+                }
+                match globals.set("host", t) {
+                    Ok(_) => (),
+                    Err(e) => errors::handle(&format!("{}{}", errors::LUA, e)),
+                }
+            }
+            Err(e) => errors::handle(&format!("{}{}", errors::LUA, e)),
+        }
+    }
+}

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod utils;
 pub(crate) mod cpu;
 pub(crate) mod gpu;
 pub(crate) mod memory;
+pub(crate) mod host;
 
 use std::fs;
 use std::path::{ Path };
@@ -42,6 +43,7 @@ use de::{ De };
 use cpu::{ Cpu };
 use gpu::{ Gpus };
 use memory::{ Memory };
+use host::Host;
 
 pub(crate) struct Info {
 	ctx: Lua,
@@ -60,6 +62,7 @@ pub(crate) struct Info {
 	pub cpu: Option<Cpu>,
 	pub gpu: Option<Gpus>,
 	pub memory: Memory,
+	pub host: Option<Host>,
 }
 
 impl Info {
@@ -77,6 +80,7 @@ impl Info {
 		let cpu = Cpu::new(&kernel);
 		let gpu = Gpus::new(&kernel);
 		let memory = Memory::new();
+		let host = Host::new(&kernel);
         Info {
 			ctx: Lua::new(),
 			rendered: String::new(),
@@ -94,6 +98,7 @@ impl Info {
 			cpu: cpu,
 			gpu: gpu,
 			memory: memory,
+			host,
 		}
 	}
 	pub fn render(&mut self) {
@@ -161,6 +166,7 @@ impl Inject for Info {
 		match &self.cpu { Some(v) => v.inject(&mut self.ctx), None => (), }
 		match &self.gpu { Some(v) => v.inject(&mut self.ctx), None => (), }
 		self.memory.inject(&mut self.ctx);
+		match &self.host { Some(v) => v.inject(&mut self.ctx), None => (), }
 		self.render();
 		{
 			let plaintext = {


### PR DESCRIPTION
This commit add support for `Host`, which queries information about the computer model and the manufacturer.