### PR TITLE
Update uptime.rs

### DIFF
--- a/src/info/uptime.rs
+++ b/src/info/uptime.rs
@@ -51,7 +51,7 @@ impl Inject for Uptime {
 
 		match lua.create_table() {
 			Ok(t) => {
-				match t.set("days", self.0.day() - 1) {
+				match t.set("days", self.0.ordinal0()) {
 					Ok(_) => (),
 					Err(e) => errors::handle(&format!("{}{}", errors::LUA, e)),
 				}


### PR DESCRIPTION
chrono::DateTime::day()
> Returns the day of month starting from 1. 

fn ordinal0(&self) -> u32
> Returns the day of year starting from 0.

If uptime greater than 31 days, it would by an incorrect result

Fix: #32 